### PR TITLE
change vuetify import to use dist files

### DIFF
--- a/src/Confirm.vue
+++ b/src/Confirm.vue
@@ -30,7 +30,7 @@
 </template>
 
 <script>
-import { VCard, VCardActions, VCardText, VDialog, VIcon, VToolbar, VToolbarTitle, VSpacer, VBtn } from 'vuetify/lib'
+import { VCard, VCardActions, VCardText, VDialog, VIcon, VToolbar, VToolbarTitle, VSpacer, VBtn } from 'vuetify'
 
 export default {
   components: {


### PR DESCRIPTION
Hello,

I changed the vuetify import, to use the dist version of vuetify.
It's important for those of us who use babel, because the externaly imported package won't be transpiled again, and in some case the "..." elipsis in vuetify lib/src package will lead to an "Unexpected token" error in some browser.

Regards,